### PR TITLE
Raise exceptions when scheduling and handle in CLI

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -249,16 +249,22 @@ class CLI:
             especialidad = input("Especialidad: ").strip()
             fecha_str = input("Fecha (DD/MM/YYYY): ").strip()
             hora_str = input("Hora (HH:MM): ").strip()
-            
+
             fecha_hora = datetime.strptime(f"{fecha_str} {hora_str}", "%d/%m/%Y %H:%M")
-            
-            resultado = self.clinica.agendar_turno(dni, matricula, especialidad, fecha_hora)
-            
-            if not resultado:
-                print("❌ No se pudo agendar el turno")
-                
+
+            self.clinica.agendar_turno(dni, matricula, especialidad, fecha_hora)
+            print("✅ Turno agendado correctamente")
+
         except ValueError:
             print("❌ Formato de fecha/hora incorrecto")
+        except PacienteNoEncontradoException as e:
+            print(f"❌ {e}")
+        except MedicoNoEncontradoException as e:
+            print(f"❌ {e}")
+        except MedicoNoDisponibleException as e:
+            print(f"❌ {e}")
+        except TurnoOcupadoException as e:
+            print(f"❌ {e}")
         except Exception as e:
             print(f"❌ Error: {e}")
     


### PR DESCRIPTION
## Summary
- Make `Clinica.agendar_turno` raise domain-specific exceptions instead of printing errors
- Capture and display those exceptions in CLI when scheduling appointments
- Update tests to assert that exceptions are raised correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e98b4faf48323b493870ad2a9a9c5